### PR TITLE
add the support for Synopsys ARC processor (#1168)

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -333,6 +333,8 @@ else ifeq ($(COMPILER),rvct)
 export TOOLCHAIN_MAKEFILE := $(MAKEFILES_PATH)/toolchain/aos_toolchain_rvct.mk
 else ifeq ($(COMPILER),iar)
 export TOOLCHAIN_MAKEFILE := $(MAKEFILES_PATH)/toolchain/aos_toolchain_iar.mk
+else ifeq ($(COMPILER), mwdt)
+export TOOLCHAIN_MAKEFILE := $(MAKEFILES_PATH)/toolchain/aos_toolchain_mwdt.mk
 else
 export TOOLCHAIN_MAKEFILE := $(MAKEFILES_PATH)/toolchain/aos_toolchain_gcc.mk
 endif

--- a/build/build_rules/aos_target_config.mk
+++ b/build/build_rules/aos_target_config.mk
@@ -408,6 +408,8 @@ else ifeq ($(COMPILER),rvct)
 include $(MAKEFILES_PATH)/toolchain/aos_toolchain_rvct.mk
 else ifeq ($(COMPILER),iar)
 include $(MAKEFILES_PATH)/toolchain/aos_toolchain_iar.mk
+else ifeq ($(COMPILER),mwdt)
+include $(MAKEFILES_PATH)/toolchain/aos_toolchain_mwdt.mk
 else
 include $(MAKEFILES_PATH)/toolchain/aos_toolchain_gcc.mk
 endif

--- a/build/build_rules/toolchain/aos_toolchain_arc_elf32.mk
+++ b/build/build_rules/toolchain/aos_toolchain_arc_elf32.mk
@@ -1,0 +1,175 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##
+
+ARC_GNU_ARCH_LIST := ARC_EM  \
+                     ARC_HS
+
+ifneq ($(filter $(HOST_ARCH), $(ARC_GNU_ARCH_LIST)),)
+
+TOOLCHAIN_PATH    ?=
+TOOLCHAIN_PREFIX  := arc-elf32-
+TOOLCHAIN_DEFAULT_FOLDER := arc-elf32
+
+ifneq (,$(wildcard $(COMPILER_ROOT)/$(TOOLCHAIN_DEFAULT_FOLDER)/$(HOST_OS)/bin))
+TOOLCHAIN_PATH    := $(COMPILER_ROOT)/$(TOOLCHAIN_DEFAULT_FOLDER)/$(HOST_OS)/bin/
+endif
+
+MBINS ?=
+
+ifeq ($(HOST_OS),Win32)
+################
+# Windows settings
+################
+
+ifeq (,$(TOOLCHAIN_PATH))
+SYSTEM_GCC_PATH = $(shell where $(TOOLCHAIN_PREFIX)gcc.exe)
+ifneq (,$(findstring $(TOOLCHAIN_PREFIX)gcc.exe,$(SYSTEM_GCC_PATH)))
+TOOLCHAIN_PATH :=
+else
+DOWNLOAD_URL   = "https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain"
+TOOLCHIAN_FILE = "arc_gnu_2019.09_ide_win_install.exe"
+$(error can not find compiler toolchain, please download $(TOOLCHIAN_FILE) from $(DOWNLOAD_URL) and install to $(COMPILER_ROOT)/$(TOOLCHAIN_DEFAULT_FOLDER)/$(HOST_OS) folder)
+endif
+endif
+
+else  # Win32
+ifneq (,$(filter $(HOST_OS),Linux32 Linux64))
+################
+# Linux 32/64-bit settings
+################
+
+ifeq (,$(TOOLCHAIN_PATH))
+SYSTEM_GCC_PATH = $(shell which $(TOOLCHAIN_PREFIX)gcc)
+ifneq (,$(findstring $(TOOLCHAIN_PREFIX)gcc,$(SYSTEM_GCC_PATH)))
+TOOLCHAIN_PATH :=
+else
+DOWNLOAD_URL   = "https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain"
+TOOLCHIAN_FILE = "arc_gnu_2019.09_ide_linux_install.tar.gz"
+$(error can not find compiler toolchain, please download $(TOOLCHIAN_FILE) from $(DOWNLOAD_URL) and unzip to $(COMPILER_ROOT)/$(TOOLCHAIN_DEFAULT_FOLDER)/$(HOST_OS) folder)
+endif
+endif
+
+else # Linux32/64
+ifeq ($(HOST_OS),OSX)
+################
+# OSX settings
+################
+
+ifeq (,$(TOOLCHAIN_PATH))
+SYSTEM_GCC_PATH = $(shell which $(TOOLCHAIN_PREFIX)gcc)
+ifneq (,$(findstring $(TOOLCHAIN_PREFIX)gcc,$(SYSTEM_GCC_PATH)))
+TOOLCHAIN_PATH :=
+else
+DOWNLOAD_URL   = "https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain"
+TOOLCHIAN_FILE = "arc_gnu_2019.09_ide_macos_install.tar.gz"
+$(error can not find compiler toolchain, please download $(TOOLCHIAN_FILE) from $(DOWNLOAD_URL) and unzip to $(COMPILER_ROOT)/$(TOOLCHAIN_DEFAULT_FOLDER)/$(HOST_OS) folder)
+endif
+endif
+
+else # OSX
+$(error unsupport OS $(HOST_OS))
+endif # OSX
+endif # Linux32 Linux64 OSX
+endif # Win32
+
+CC      := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)gcc$(EXECUTABLE_SUFFIX)"
+CXX     := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)g++$(EXECUTABLE_SUFFIX)"
+AS      := $(CC)
+AR      := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)ar$(EXECUTABLE_SUFFIX)"
+LD      := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)ld$(EXECUTABLE_SUFFIX)"
+CPP     := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)cpp$(EXECUTABLE_SUFFIX)"
+OBJDUMP := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)objdump$(EXECUTABLE_SUFFIX)"
+OBJCOPY := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)objcopy$(EXECUTABLE_SUFFIX)"
+STRIP   := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)strip$(EXECUTABLE_SUFFIX)"
+NM      := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)nm$(EXECUTABLE_SUFFIX)"
+READELF := "$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)readelf$(EXECUTABLE_SUFFIX)"
+
+ADD_COMPILER_SPECIFIC_STANDARD_CFLAGS   = $(1) -Wall -Wfatal-errors -Wno-error=format -Wno-error=incompatible-pointer-types  -Wno-stringop-truncation -Wno-stringop-overflow -fsigned-char -ffunction-sections -fdata-sections -fno-common -mno-sdata -std=gnu99
+ADD_COMPILER_SPECIFIC_STANDARD_CXXFLAGS = $(1) -Wall -Wfatal-errors -Wno-error=format -Wno-error=incompatible-pointer-types  -Wno-stringop-truncation -Wno-stringop-overflow -fsigned-char -ffunction-sections -fdata-sections -fno-common -mno-sdata -fno-rtti -fno-exceptions
+ADD_COMPILER_SPECIFIC_STANDARD_ADMFLAGS = $(1)
+COMPILER_SPECIFIC_OPTIMIZED_CFLAGS    := -O2
+COMPILER_SPECIFIC_UNOPTIMIZED_CFLAGS  := -Og
+COMPILER_SPECIFIC_PEDANTIC_CFLAGS  := $(COMPILER_SPECIFIC_STANDARD_CFLAGS) -Werror -Wstrict-prototypes  -W -Wshadow  -Wwrite-strings -pedantic -std=c99 -U__STRICT_ANSI__ -Wconversion -Wextra -Wdeclaration-after-statement -Wconversion -Waddress -Wlogical-op -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes -Wmissing-declarations -Wmissing-field-initializers -Wdouble-promotion -Wswitch-enum -Wswitch-default -Wuninitialized -Wunknown-pragmas -Wfloat-equal  -Wundef  -Wshadow # -Wcast-qual -Wtraditional -Wtraditional-conversion
+COMPILER_SPECIFIC_ARFLAGS_CREATE   := -rcs
+COMPILER_SPECIFIC_ARFLAGS_ADD      := -rcs
+COMPILER_SPECIFIC_ARFLAGS_VERBOSE  := -v
+
+# debug: no optimize, full exception inspect and log enabled
+COMPILER_SPECIFIC_DEBUG_CFLAGS     := -DDEBUG -ggdb $(COMPILER_SPECIFIC_UNOPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_DEBUG_CXXFLAGS   := -DDEBUG -ggdb $(COMPILER_SPECIFIC_UNOPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_DEBUG_ASFLAGS    := -DDEBUG=1 -ggdb
+COMPILER_SPECIFIC_DEBUG_LDFLAGS    := -Wl,--gc-sections -Wl,--cref
+
+# inspect: optimize, full exception inspect and log enabled
+COMPILER_SPECIFIC_INSPECT_CFLAGS   := -DDEBUG -ggdb $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_INSPECT_CXXFLAGS := -DDEBUG -ggdb $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_INSPECT_ASFLAGS  := -DDEBUG=1 -ggdb
+COMPILER_SPECIFIC_INSPECT_LDFLAGS  := -Wl,--gc-sections -Wl,$(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS) -Wl,--cref
+
+# release_log: optimize, minimal exception inspect and less log
+COMPILER_SPECIFIC_RELEASE_LOG_CFLAGS   := -ggdb $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_RELEASE_LOG_CXXFLAGS := -ggdb $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_RELEASE_LOG_ASFLAGS  := -ggdb
+COMPILER_SPECIFIC_RELEASE_LOG_LDFLAGS  := -Wl,--gc-sections -Wl,$(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS) -Wl,--cref
+
+# release: optimize, and log, cli, exception inspect disabled
+COMPILER_SPECIFIC_RELEASE_CFLAGS   := -DNDEBUG -ggdb $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_RELEASE_CXXFLAGS := -DNDEBUG -ggdb $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_RELEASE_ASFLAGS  := -ggdb
+COMPILER_SPECIFIC_RELEASE_LDFLAGS  := -Wl,--gc-sections -Wl,$(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS) -Wl,--cref
+
+COMPILER_SPECIFIC_DEPS_FLAG        := -MD
+COMPILER_SPECIFIC_COMP_ONLY_FLAG   := -c
+COMPILER_SPECIFIC_LINK_MAP         =  -Wl,-M,-Map=$(1)
+COMPILER_SPECIFIC_LINK_FILES       = -Wl,--start-group $(1) -lm -lc -lgcc -Wl,--end-group
+COMPILER_SPECIFIC_LINK_SCRIPT_DEFINE_OPTION = -Wl$(COMMA)-T
+COMPILER_SPECIFIC_LINK_SCRIPT      =  $(addprefix -Wl$(COMMA)-T ,$(1))
+
+ifeq ($(strip $(AOS_CPLUSPLUS_FLAGS)), 1)
+LINKER                             := $(CXX) --static -Wl,-static -Wl,--warn-common -mno-sdata -nostartfiles
+else
+LINKER                             := $(CC) --static -Wl,-static -Wl,--warn-common -mno-sdata -nostartfiles
+endif
+
+LINK_SCRIPT_SUFFIX                 := .ld
+TOOLCHAIN_NAME := GCC
+OPTIONS_IN_FILE_OPTION    := @
+
+ENDIAN_CFLAGS_LITTLE   := -mlittle-endian
+ENDIAN_CXXFLAGS_LITTLE := -mlittle-endian
+ENDIAN_ASMFLAGS_LITTLE :=
+ENDIAN_LDFLAGS_LITTLE  := -mlittle-endian
+CLIB_LDFLAGS_NANO      := --specs=nano.specs
+CLIB_LDFLAGS_NANO_FLOAT:= --specs=nano.specs -u _printf_float
+
+# Chip specific flags for GCC
+
+CPU_CFLAGS     :=
+CPU_CXXFLAGS   :=
+CPU_ASMFLAGS   := -x assembler-with-cpp
+CPU_LDFLAGS    :=
+
+# $(1) is map file, $(2) is CSV output file
+COMPILER_SPECIFIC_MAPFILE_TO_CSV = $(PYTHON) $(MAPFILE_PARSER) $(1) > $(2)
+
+MAPFILE_PARSER            :=$(SCRIPTS_PATH)/map_parse_gcc.py
+
+# $(1) is map file, $(2) is CSV output file
+COMPILER_SPECIFIC_MAPFILE_DISPLAY_SUMMARY = $(PYTHON) $(MAPFILE_PARSER) $(1)
+
+#KILL_OPENOCD_SCRIPT := $(MAKEFILES_PATH)/kill_openocd.py
+
+#KILL_OPENOCD = $(PYTHON) $(KILL_OPENOCD_SCRIPT)
+
+STRIP_OUTPUT_PREFIX := -o
+OBJCOPY_BIN_FLAGS   := -O binary -R .eh_frame -R .init -R .fini -R .comment -R .ARM.attributes
+OBJCOPY_HEX_FLAGS   := -O ihex -R .eh_frame -R .init -R .fini -R .comment -R .ARM.attributes
+
+LINK_OUTPUT_SUFFIX :=.elf
+BIN_OUTPUT_SUFFIX  :=.bin
+HEX_OUTPUT_SUFFIX  :=.hex
+
+endif # ifneq ($(filter $(HOST_ARCH), $(ARC_GNU_ARCH_LIST)),)

--- a/build/build_rules/toolchain/aos_toolchain_gcc.mk
+++ b/build/build_rules/toolchain/aos_toolchain_gcc.mk
@@ -7,3 +7,4 @@ include $(MAKEFILES_PATH)/toolchain/aos_toolchain_csky.mk
 include $(MAKEFILES_PATH)/toolchain/aos_toolchain_mips.mk
 include $(MAKEFILES_PATH)/toolchain/aos_toolchain_riscv32_unkown_elf_gcc.mk
 include $(MAKEFILES_PATH)/toolchain/aos_toolchain_nds32le-elf-newlib-v3.mk
+include $(MAKEFILES_PATH)/toolchain/aos_toolchain_arc_elf32.mk

--- a/build/build_rules/toolchain/aos_toolchain_mwdt.mk
+++ b/build/build_rules/toolchain/aos_toolchain_mwdt.mk
@@ -1,0 +1,106 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##
+
+TOOLCHAIN_PATH ?=
+TOOLCHAIN_PREFIX :=
+CC      := $(TOOLCHAIN_PATH)ccac
+CXX     := $(TOOLCHAIN_PATH)ccac
+AS      := $(TOOLCHAIN_PATH)ccac
+AR      := $(TOOLCHAIN_PATH)arac
+LD      := $(TOOLCHAIN_PATH)ccac
+CPP     := $(TOOLCHAIN_PATH)ccac
+
+# OPTIONS_IN_FILE_OPTION_PREFIX_DIRECT  = $
+OPTIONS_IN_FILE_OPTION_PREFIX         = @
+# OPTIONS_IN_FILE_OPTION                = (file <
+# OPTIONS_IN_FILE_OPTION_SUFFIX         = )
+# OBJCOPYFLAGS := --bin --output=
+
+ADD_COMPILER_SPECIFIC_STANDARD_CFLAGS   = $(1)-Hnoccm -Hnosdata -Wincompatible-pointer-types -Wno-builtin-macro-redefined -Wno-implicit-function-declaration -Hnocopyr -Hpurge
+ADD_COMPILER_SPECIFIC_STANDARD_CXXFLAGS = $(1) -Hnoccm -Hnosdata -Wincompatible-pointer-types -Wno-builtin-macro-redefined -Wno-implicit-function-declaration -Hnocopyr -Hpurge
+ADD_COMPILER_SPECIFIC_STANDARD_ADMFLAGS = $(1)
+COMPILER_SPECIFIC_OPTIMIZED_CFLAGS     := -O0
+COMPILER_SPECIFIC_UNOPTIMIZED_CFLAGS   := -Og
+COMPILER_SPECIFIC_PEDANTIC_CFLAGS      := $(COMPILER_SPECIFIC_STANDARD_CFLAGS)
+COMPILER_SPECIFIC_ARFLAGS_CREATE       := -rsq
+COMPILER_SPECIFIC_ARFLAGS_ADD          := -rsq
+COMPILER_SPECIFIC_ARFLAGS_VERBOSE      := -v
+
+# debug: no optimize, full exception inspect and log enabled
+COMPILER_SPECIFIC_DEBUG_CFLAGS         := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_DEBUG_CXXFLAGS       := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_DEBUG_ASFLAGS        := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS) -Hnoccm -Hnosdata -Wincompatible-pointer-types -Wno-builtin-macro-redefined -Wno-implicit-function-declaration -Hnocopyr -Hpurge
+COMPILER_SPECIFIC_DEBUG_LDFLAGS        :=
+
+# inspect: optimize, full exception inspect and log enabled
+COMPILER_SPECIFIC_INSPECT_CFLAGS       := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_INSPECT_CXXFLAGS     := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_INSPECT_ASFLAGS      := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS) -Hnoccm -Hnosdata -Wincompatible-pointer-types -Wno-builtin-macro-redefined -Wno-implicit-function-declaration -Hnocopyr -Hpurge
+COMPILER_SPECIFIC_INSPECT_LDFLAGS      :=
+
+# release_log: optimize, minimal exception inspect and less log
+COMPILER_SPECIFIC_RELEASE_LOG_CFLAGS   := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_RELEASE_LOG_CXXFLAGS := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_RELEASE_LOG_ASFLAGS  := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS) -Hnoccm -Hnosdata -Wincompatible-pointer-types -Wno-builtin-macro-redefined -Wno-implicit-function-declaration -Hnocopyr -Hpurge
+COMPILER_SPECIFIC_RELEASE_LOG_LDFLAGS  :=
+
+# release: optimize, and log, cli, exception inspect disabled
+COMPILER_SPECIFIC_RELEASE_CFLAGS       := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_RELEASE_CXXFLAGS     := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS)
+COMPILER_SPECIFIC_RELEASE_ASFLAGS      := -g $(COMPILER_SPECIFIC_OPTIMIZED_CFLAGS) -Hnoccm -Hnosdata -Wincompatible-pointer-types -Wno-builtin-macro-redefined -Wno-implicit-function-declaration -Hnocopyr -Hpurge
+COMPILER_SPECIFIC_RELEASE_LDFLAGS      :=
+
+# -MD -> --dependencies xx.d
+COMPILER_SPECIFIC_DEPS_FLAG                := -MMD
+COMPILER_SPECIFIC_DEPS_FILE                 = -MF $(1)
+COMPILER_SPECIFIC_COMP_ONLY_FLAG           := -c
+COMPILER_SPECIFIC_LINK_MAP                  = -Hldopt=-Coutput=$(1) -Hldopt=-Csections -Hldopt=-Ccrossfunc -Hldopt=-Csize -zstdout -Hldopt=-Bgrouplib
+COMPILER_SPECIFIC_LINK_FILES                = $(1)
+COMPILER_SPECIFIC_LINK_SCRIPT_DEFINE_OPTION =
+COMPILER_SPECIFIC_LINK_SCRIPT               =
+
+LINKER                             := $(LD)
+LINK_SCRIPT_SUFFIX                 := .icf
+TOOLCHAIN_NAME := mwdt
+
+ENDIAN_CFLAGS_LITTLE   := --littleend
+ENDIAN_CXXFLAGS_LITTLE := --littleend
+ENDIAN_ASMFLAGS_LITTLE :=
+ENDIAN_LDFLAGS_LITTLE  := --littleend
+CLIB_LDFLAGS_NANO      :=
+CLIB_LDFLAGS_NANO_FLOAT:=
+
+# Chip specific flags for compiler
+CPU_CFLAGS     :=
+CPU_CXXFLAGS   :=
+CPU_ASMFLAGS   := -Hasmcpp -MMD
+CPU_LDFLAGS    :=
+
+# $(1) is map file, $(2) is CSV output file
+#COMPILER_SPECIFIC_MAPFILE_TO_CSV = $(PYTHON) $(MAPFILE_PARSER) $(1) > $(2)
+
+#TODO
+#MAPFILE_PARSER            :=$(SCRIPTS_PATH)/map_parse_gcc.py
+
+# $(1) is map file, $(2) is CSV output file
+# mwdt map file format is different
+# COMPILER_SPECIFIC_MAPFILE_DISPLAY_SUMMARY = $(PYTHON) $(MAPFILE_PARSER) $(1)
+
+OBJDUMP := $(TOOLCHAIN_PATH)stripac
+OBJCOPY := $(TOOLCHAIN_PATH)elf2hex
+
+OBJCOPY_OUTPUT_PREFIX := -o
+OBJCOPY_BIN_FLAGS   := -B
+OBJCOPY_HEX_FLAGS   := -Q -I
+
+STRIP   := $(TOOLCHAIN_PATH)stripac
+# STRIPFLAGS := --strip --silent
+#STRIP_OUTPUT_PREFIX := -o
+
+LINK_OUTPUT_SUFFIX  :=.elf
+BIN_OUTPUT_SUFFIX   :=.bin
+HEX_OUTPUT_SUFFIX   :=.hex
+

--- a/platform/arch/arc/Config.in
+++ b/platform/arch/arc/Config.in
@@ -1,0 +1,5 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##

--- a/platform/arch/arc/aos.mk
+++ b/platform/arch/arc/aos.mk
@@ -1,0 +1,20 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##
+
+NAME := arch_arc
+
+$(NAME)_MBINS_TYPE := kernel
+$(NAME)_VERSION    := 1.0.0
+$(NAME)_SUMMARY    := arch for arc
+
+$(NAME)_SOURCES := port_s.s
+$(NAME)_SOURCES += port_c.c
+
+$(NAME)_INCLUDES += .
+
+GLOBAL_INCLUDES += include
+
+# $(info [arc_arc.info]: GLOBAL_INCLUDES = $(GLOBAL_INCLUDES))

--- a/platform/arch/arc/include/k_compiler.h
+++ b/platform/arch/arc/include/k_compiler.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef K_COMPILER_H
+#define K_COMPILER_H
+
+#define RHINO_INLINE                static inline
+/* get the return address of the current function
+   void * __builtin_return_address (unsigned int level) */
+#define RHINO_GET_RA()              __builtin_return_address(0)
+/* get the return address of the current function */
+__attribute__((always_inline)) RHINO_INLINE void *RHINO_GET_SP(void)
+{
+    void *stack_point;
+    asm volatile("mov %0, %%sp\n" : "=r" (stack_point));
+    return stack_point;
+}
+/* get the number of leading 0-bits in x
+   int __builtin_clz (unsigned int x) */
+//#define RHINO_BIT_CLZ(x)            __builtin_clz(x)
+
+#ifndef RHINO_WEAK
+#define RHINO_WEAK                  __attribute__((weak))
+#endif
+
+#ifndef RHINO_ASM
+#define RHINO_ASM                   __asm__
+#endif
+
+#endif /* K_COMPILER_H */

--- a/platform/arch/arc/include/k_types.h
+++ b/platform/arch/arc/include/k_types.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TYPES_H
+#define TYPES_H
+
+#include "k_compiler.h"
+
+#define RHINO_TASK_STACK_OVF_MAGIC \
+    0xdeadbeafu /* 32 bit or 64 bit stack overflow magic value */
+#define RHINO_INTRPT_STACK_OVF_MAGIC \
+    0xdeaddeadu /* 32 bit or 64 bit stack overflow magic value */
+#define RHINO_MM_CORRUPT_DYE 0xFEFEFEFE
+#define RHINO_MM_FREE_DYE 0xABABABAB
+#define RHINO_INLINE                                                         \
+    static inline /* inline keyword, it may change under different compilers \
+                   */
+
+typedef char     name_t;
+typedef uint32_t sem_count_t;
+typedef uint32_t cpu_stack_t;
+typedef uint32_t hr_timer_t;
+typedef uint32_t lr_timer_t;
+typedef uint32_t mutex_nested_t;
+typedef uint8_t  suspend_nested_t;
+typedef uint64_t ctx_switch_t;
+typedef uint32_t cpu_cpsr_t;
+
+#endif /* TYPES_H */

--- a/platform/arch/arc/include/port.h
+++ b/platform/arch/arc/include/port.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PORT_H
+#define PORT_H
+
+cpu_cpsr_t cpu_intrpt_save(void);
+void   cpu_intrpt_restore(cpu_cpsr_t cpsr);
+void   cpu_intrpt_switch(void);
+void   cpu_task_switch(void);
+void   cpu_first_task_start(void);
+void  *cpu_task_stack_init(cpu_stack_t *base, size_t size, void *arg, task_entry_t entry);
+
+RHINO_INLINE uint8_t cpu_cur_get(void)
+{
+    return 0;
+}
+
+#define CPSR_ALLOC()                cpu_cpsr_t cpsr
+#define RHINO_CPU_INTRPT_DISABLE()  do{cpsr = cpu_intrpt_save();}while(0)
+#define RHINO_CPU_INTRPT_ENABLE()   do{cpu_intrpt_restore(cpsr);}while(0)
+
+#endif /* PORT_H */

--- a/platform/arch/arc/port_c.c
+++ b/platform/arch/arc/port_c.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <k_api.h>
+#include "arc/arc_exception.h"
+
+#if ARC_FEATURE_STACK_CHECK
+#define ARC_INIT_STATUS ((1 << AUX_STATUS_BIT_SC) | AUX_STATUS_MASK_IE | ((-1 - INT_PRI_MIN) << 1) | STATUS32_RESET_VALUE)
+#else
+#define ARC_INIT_STATUS (AUX_STATUS_MASK_IE | ((-1 - INT_PRI_MIN) << 1) | STATUS32_RESET_VALUE)
+#endif
+
+extern void start_r(void);
+
+uint32_t g_context_switch_reqflg;
+uint32_t g_exc_nest_count;
+
+struct init_stack_frame {
+    uint32_t pc;
+    uint32_t blink;
+    uint32_t task;
+    uint32_t status32;
+    uint32_t r0;
+};
+
+void *cpu_task_stack_init(cpu_stack_t *stack_base, size_t stack_size,
+                          void *arg, task_entry_t entry)
+{
+    struct init_stack_frame *stack_frame;
+    cpu_stack_t *stk;
+
+    uint32_t temp = (uint32_t)(stack_base + stack_size);
+    /* stack aligned by 8 byte */
+    temp &= 0xfffffffc;
+    stk = (cpu_stack_t *)temp;
+
+    stk -= sizeof(struct init_stack_frame);
+
+    stack_frame = (struct init_stack_frame *)stk;
+
+    stack_frame->pc = (uint32_t)start_r;
+    stack_frame->blink = (uint32_t)krhino_task_deathbed;
+    stack_frame->task = (uint32_t)entry;
+    stack_frame->status32 = ARC_INIT_STATUS;
+	stack_frame->r0 = (uint32_t)arg;
+
+    return stk;
+}
+
+void set_hw_stack_check(ktask_t *from, ktask_t *to)
+{
+	if (to != NULL) {
+#if ARC_FEATURE_SEC_PRESENT
+		arc_aux_write(AUX_S_KSTACK_TOP, (uint32_t)(to->task_stack_base));
+		arc_aux_write(AUX_S_KSTACK_BASE, (uint32_t)(to->task_stack_base + to->stack_size);
+#else
+		arc_aux_write(AUX_KSTACK_TOP, (uint32_t)(to->task_stack_base));
+		arc_aux_write(AUX_KSTACK_BASE, (uint32_t)(to->task_stack_base + to->stack_size));
+#endif
+	}
+}

--- a/platform/arch/arc/port_s.s
+++ b/platform/arch/arc/port_s.s
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#define __ASSEMBLY__
+#include "include/arc/arc.h"
+#include "include/arc/arc_asm_common.h"
+
+.global g_active_task;
+.global g_preferred_ready_task;
+.global g_exc_nest_count;
+.global g_context_switch_reqflg;
+.global set_hw_stack_check;
+
+.global krhino_intrpt_enter;
+.global krhino_intrpt_exit;
+
+	.text
+	.align 4
+dispatcher:
+	st sp, [r0]	//ld 	r0, [g_active_task]
+	ld sp, [r1]	//ld 	r1, [g_preferred_ready_task]
+	st r1, [g_active_task]
+#if ARC_FEATURE_STACK_CHECK
+#if ARC_FEATURE_SEC_PRESENT
+	lr r0, [AUX_SEC_STAT]
+	bclr r0, r0, AUX_SEC_STAT_BIT_SSC
+	sflag r0
+#else
+	lr r0, [AUX_STATUS32]
+	bclr r0, r0, AUX_STATUS_BIT_SC
+	kflag r0
+#endif
+	jl	set_hw_stack_check
+#if ARC_FEATURE_SEC_PRESENT
+	lr r0, [AUX_SEC_STAT]
+	bset r0, r0, AUX_SEC_STAT_BIT_SSC
+	sflag r0
+#else
+	lr r0, [AUX_STATUS32]
+	bset r0, r0, AUX_STATUS_BIT_SC
+	kflag r0
+#endif
+#endif
+	pop r0
+	j [r0]
+
+/* return routine when task dispatch happened in task context */
+dispatch_r:
+	RESTORE_NONSCRATCH_REGS
+	j	[blink]
+
+/*
+ * size_t cpu_intrpt_save(void);
+ */
+    .global cpu_intrpt_save
+    .align 4
+cpu_intrpt_save:
+    clri r0
+    j [blink]
+
+/*
+ * void cpu_intrpt_restore(size_t cpsr);
+ */
+    .global cpu_intrpt_restore
+    .align 4
+cpu_intrpt_restore:
+    seti r0
+    j [blink]
+
+/*
+ * void cpu_first_task_start(void);
+ */
+    .global cpu_first_task_start
+    .align 4
+cpu_first_task_start:
+    ld r0, [g_active_task]
+    ld sp, [r0]
+#if ARC_FEATURE_STACK_CHECK
+    mov r1, r0
+#if ARC_FEATURE_SEC_PRESENT
+    lr r0, [AUX_SEC_STAT]
+    bclr r0, r0, AUX_SEC_STAT_BIT_SSC
+    sflag r0
+#else
+    lr r0, [AUX_STATUS32]
+    bclr r0, r0, AUX_STATUS_BIT_SC
+    kflag r0
+#endif
+    jl	set_hw_stack_check
+#if ARC_FEATURE_SEC_PRESENT
+    lr r0, [AUX_SEC_STAT]
+    bset r0, r0, AUX_SEC_STAT_BIT_SSC
+    sflag r0
+#else
+    lr r0, [AUX_STATUS32]
+    bset r0, r0, AUX_STATUS_BIT_SC
+    kflag r0
+#endif
+#endif
+    pop r0
+    j [r0]
+
+/*
+ * void cpu_intrpt_switch(void);
+ */
+	.global cpu_intrpt_switch
+	.align 4
+cpu_intrpt_switch:
+	mov r0, 1
+	st r0, [g_context_switch_reqflg]
+	j [blink]
+
+/*
+ * void cpu_task_switch(void);
+ */
+	.global cpu_task_switch
+	.align 4
+cpu_task_switch:
+	SAVE_NONSCRATCH_REGS
+	mov r2, dispatch_r
+	push r2
+	ld 	r0, [g_active_task]
+	ld 	r1, [g_preferred_ready_task]
+	b dispatcher
+
+/*
+ * void start_r(void);
+ */
+	.global start_r
+	.align 4
+start_r:
+	pop blink;
+	pop r1
+	pop r2
+	pop r0
+
+	j_s.d [r1]
+	kflag r2
+
+/****** exceptions and interrupts handing ******/
+/****** entry for exception handling ******/
+	.global exc_entry_cpu
+	.align 4
+exc_entry_cpu:
+
+	EXCEPTION_PROLOGUE
+
+	mov	blink,	sp
+	mov	r3, sp		/* as exception handler's para(p_excinfo) */
+
+	ld	r0, [g_exc_nest_count]
+	add	r1, r0, 1
+	st	r1, [g_exc_nest_count]
+	brne	r0, 0, exc_handler_1
+/* change to exception stack if interrupt happened in task context */
+	mov	sp, _e_stack
+exc_handler_1:
+	PUSH	blink
+
+	lr	r0, [AUX_ECR]
+	lsr	r0, r0, 16
+	mov	r1, exc_int_handler_table
+	ld.as	r2, [r1, r0]
+
+	mov	r0, r3
+	jl	[r2]
+
+/* interrupts are not allowed */
+ret_exc:
+	POP	sp
+	mov	r1, g_exc_nest_count
+	ld	r0, [r1]
+	sub	r0, r0, 1
+	st	r0, [r1]
+	brne	r0, 0, ret_exc_1 /* nest exception case */
+	lr	r1, [AUX_IRQ_ACT] /* nest interrupt case */
+	brne	r1, 0, ret_exc_1
+
+	ld	r0, [g_context_switch_reqflg]
+	brne	r0, 0, ret_exc_2
+ret_exc_1:	/* return from non-task context, interrupts or exceptions are nested */
+	EXCEPTION_EPILOGUE
+	rtie
+
+/* there is a dispatch request */
+ret_exc_2:
+	/* clear dispatch request */
+	mov	r0, 0
+	st	r0, [g_context_switch_reqflg]
+
+	SAVE_CALLEE_REGS	/* save callee save registers */
+
+	/* clear exception bit to do exception exit by SW */
+	lr	r0, [AUX_STATUS32]
+	bclr	r0, r0, AUX_STATUS_BIT_AE
+	kflag	r0
+
+	mov	r1, ret_exc_r	/* save return address */
+	PUSH	r1
+
+	ld 	r0, [g_active_task]
+	ld 	r1, [g_preferred_ready_task]
+	b	dispatcher
+
+ret_exc_r:
+	/* recover exception status */
+	lr	r0, [AUX_STATUS32]
+	bset	r0, r0, AUX_STATUS_BIT_AE
+	kflag	r0
+
+	RESTORE_CALLEE_REGS
+	EXCEPTION_EPILOGUE
+	rtie
+
+/****** entry for normal interrupt exception handling ******/
+	.global exc_entry_int	/* entry for interrupt handling */
+	.align 4
+exc_entry_int:
+#if ARC_FEATURE_FIRQ == 1
+/*  check whether it is P0 interrupt */
+#if ARC_FEATURE_RGF_NUM_BANKS > 1
+	lr	r0, [AUX_IRQ_ACT]
+	btst	r0, 0
+	jnz	exc_entry_firq
+#else
+	PUSH	r10
+	lr	r10, [AUX_IRQ_ACT]
+	btst	r10, 0
+	POP	r10
+	jnz	exc_entry_firq
+#endif
+#endif
+	INTERRUPT_PROLOGUE
+
+	mov	blink, sp
+
+	clri	/* disable interrupt */
+	ld	r3, [g_exc_nest_count]
+	add	r2, r3, 1
+	st	r2, [g_exc_nest_count]
+	seti	/* enable higher priority interrupt */
+
+	brne	r3, 0, irq_handler_1
+/* change to exception stack if interrupt happened in task context */
+	mov	sp, _e_stack
+#if ARC_FEATURE_STACK_CHECK
+#if ARC_FEATURE_SEC_PRESENT
+	lr r0, [AUX_SEC_STAT]
+	bclr r0, r0, AUX_SEC_STAT_BIT_SSC
+	sflag r0
+#else
+	lr r0, [AUX_STATUS32]
+	bclr r0, r0, AUX_STATUS_BIT_SC
+	kflag r0
+#endif
+#endif
+irq_handler_1:
+	PUSH	blink
+
+	jl 	krhino_intrpt_enter
+
+	lr	r0, [AUX_IRQ_CAUSE]
+	sr	r0, [AUX_IRQ_SELECT]
+	mov	r1, exc_int_handler_table
+	ld.as	r2, [r1, r0]	/* r2 = exc_int_handler_table + irqno *4 */
+/* handle software triggered interrupt */
+	lr	r3, [AUX_IRQ_HINT]
+	cmp	r3, r0
+	bne.d irq_hint_handled
+	xor	r3, r3, r3
+	sr	r3, [AUX_IRQ_HINT]
+irq_hint_handled:
+	lr	r3, [AUX_IRQ_PRIORITY]
+	PUSH	r3		/* save irq priority */
+
+	jl	[r2]		/* jump to interrupt handler */
+	jl	krhino_intrpt_exit
+ret_int:
+	clri			/* disable interrupt */
+	POP	r3		/* irq priority */
+	POP	sp
+	mov	r1, g_exc_nest_count
+	ld	r0, [r1]
+	sub	r0, r0, 1
+	st	r0, [r1]
+/* if there are multi-bits set in IRQ_ACT, it's still in nest interrupt */
+	lr	r0, [AUX_IRQ_CAUSE]
+	sr	r0, [AUX_IRQ_SELECT]
+	lr 	r3, [AUX_IRQ_PRIORITY]
+	lr	r1, [AUX_IRQ_ACT]
+	bclr	r2, r1, r3
+	brne	r2, 0, ret_int_1
+
+	ld	r0, [g_context_switch_reqflg]
+	brne	r0, 0, ret_int_2
+ret_int_1:	/* return from non-task context */
+	INTERRUPT_EPILOGUE
+	rtie
+/* there is a dispatch request */
+ret_int_2:
+	/* clear dispatch request */
+	mov	r0, 0
+	st	r0, [g_context_switch_reqflg]
+
+	/* interrupt return by SW */
+	lr	r10, [AUX_IRQ_ACT]
+	PUSH	r10
+	bclr	r10, r10, r3	/* clear related bits in IRQ_ACT */
+	sr	r10, [AUX_IRQ_ACT]
+
+	SAVE_CALLEE_REGS	/* save callee save registers */
+	mov	r1, ret_int_r	/* save return address */
+	PUSH	r1
+
+	ld 	r0, [g_active_task]
+	ld 	r1, [g_preferred_ready_task]
+	b	dispatcher
+
+ret_int_r:
+	RESTORE_CALLEE_REGS
+	/* recover AUX_IRQ_ACT to restore the interrup status */
+	POPAX	AUX_IRQ_ACT
+	INTERRUPT_EPILOGUE
+	rtie
+
+/****** entry for fast irq exception handling ******/
+	.global exc_entry_firq
+	.weak exc_entry_firq
+	.align 4
+exc_entry_firq:
+	SAVE_FIQ_EXC_REGS
+
+	lr	r0, [AUX_IRQ_CAUSE]
+	mov	r1, exc_int_handler_table
+/* r2 = _kernel_exc_tbl + irqno *4 */
+	ld.as	r2, [r1, r0]
+
+/* for the case of software triggered interrupt */
+	lr	r3, [AUX_IRQ_HINT]
+	cmp	r3, r0
+	bne.d	firq_hint_handled
+	xor	r3, r3, r3
+	sr	r3, [AUX_IRQ_HINT]
+firq_hint_handled:
+/* jump to interrupt handler */
+	mov	r0, sp
+	jl	[r2]
+
+firq_return:
+	RESTORE_FIQ_EXC_REGS
+	rtie

--- a/platform/board/Config.in
+++ b/platform/board/Config.in
@@ -66,6 +66,15 @@ if AOS_BOARD_LINUXHOST
     source "platform/arch/linux/Config.in"
 endif
 
+source "platform/board/nsim_em/Config.in"
+if AOS_BOARD_NSIM_EM
+    config AOS_BUILD_BOARD
+        default "nsim_em"
+
+    source "platform/mcu/embarc/Config.in"
+    source "platform/arch/arc/Config.in"
+endif
+
 source "platform/board/board_legacy/xmc4800-relax/Config.in"
 if AOS_BOARD_XMC4800_RELAX
     config AOS_BUILD_BOARD

--- a/platform/board/nsim_em/Config.in
+++ b/platform/board/nsim_em/Config.in
@@ -1,0 +1,19 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##
+
+config AOS_BOARD_NSIM_EM
+    bool "Synopsys DesignWare ARC NSIM_EM Board"
+    select AOS_MCU_EMBARC
+    select CONFIG_NO_TCPIP
+    #select AOS_COMP_KERNEL_INIT
+    #select AOS_COMP_OSAL_AOS
+    help
+      configuration for board NSIM_EM
+
+if AOS_BOARD_NSIM_EM
+#configuration for board NSIM_EM
+
+endif #AOS_BOARD_NSIM_EM

--- a/platform/board/nsim_em/README.md
+++ b/platform/board/nsim_em/README.md
@@ -1,0 +1,10 @@
+# Virtual Board based on ARC nSIM
+
+The DesignWare® ARC® nSIM Instruction Set Simulator provides an instruction
+accurate processor model for the DesignWare ARC processor families. Such
+processor models take the software development out of your products’ critical
+path by enabling an early start as well as increased efficiency through
+enhanced visibility and control. A basic test environment for nSIM is
+implemented in embARC, where hostlink IO is used for message input and output.
+ARC related functions can be tested using nSIM such as internal timer, cache
+module, interrupt and exception module.

--- a/platform/board/nsim_em/aos.mk
+++ b/platform/board/nsim_em/aos.mk
@@ -1,0 +1,74 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##
+
+NAME := board_nsim_em
+
+$(NAME)_MBINS_TYPE := kernel
+$(NAME)_VERSION    := 1.0.0
+$(NAME)_SUMMARY    := configuration for board nsim_em
+
+MODULE             := 1062
+HOST_ARCH          := ARC_EM
+HOST_MCU_FAMILY    := mcu_embarc
+SUPPORT_MBINS      := no
+HOST_MCU_NAME      := NSIM_EM
+
+$(NAME)_COMPONENTS += $(HOST_MCU_FAMILY) osal_aos kernel_init
+
+$(NAME)_SOURCES += k_config.c
+$(NAME)_SOURCES += startup.c
+$(NAME)_SOURCES += board.c
+
+BOARD ?= nsim
+BD_VER ?= 10
+CUR_CORE ?= arcem
+
+ifeq ($(COMPILER), mwdt)
+TOOLCHAIN := mw
+else
+TOOLCHAIN := gnu
+endif
+
+export BOARD
+export BD_VER
+export CUR_CORE
+export TOOLCHAIN
+
+
+
+# $(NAME)_SOURCES +=
+
+GLOBAL_DEFINES += CONFIG_NO_TCPIP
+
+#depends on sal module if select sal function via build option "AOS_NETWORK_SAL=y"
+AOS_NETWORK_SAL	?= n
+
+ifeq ($(COMPILER),mwdt)
+#GLOBAL_LDFLAGS +=  -Hhostlink
+TOOLCHAIN_DEF := -D__MW__
+else
+#GLOBAL_LDFLAGS +=  --specs=nsim.specs
+TOOLCHAIN_DEF := -D__GNU__ -D_HAVE_LIBGLOSS_
+endif
+
+GLOBAL_INCLUDES += .
+
+NSIM_STACK_CHECK := -DARC_FEATURE_STACK_CHECK=0 # 1: enable hardware stack check, 0 disable hardware stack check
+
+NISM_BOARD_FLAGS := $(NSIM_STACK_CHECK) $(TOOLCHAIN_DEF) -DBOARD_NSIM -DCURRENT_CORE=arcem -DEMBARC_TCF_GENERATED -DHW_VERSION=10 -DLIB_CLIB -DLIB_CONSOLE -D_HEAPSIZE=8192 -D_NSIM_ -D_STACKSIZE=2048 -D__MW__
+
+GLOBAL_CFLAGS += $(NISM_BOARD_FLAGS)
+GLOBAL_ASMFLAGS += $(NISM_BOARD_FLAGS)
+GLOBAL_CXXFLAGS += $(NISM_BOARD_FLAGS)
+
+CONFIG_SYSINFO_PRODUCT_MODEL := ALI_AOS_NSIM
+CONFIG_SYSINFO_DEVICE_NAME   := SYNOPSYS_ARC_NSIM
+
+# GLOBAL_CFLAGS += -DSYSINFO_PRODUCT_MODEL=\"$(CONFIG_SYSINFO_PRODUCT_MODEL)\"
+# GLOBAL_CFLAGS += -DSYSINFO_DEVICE_NAME=\"$(CONFIG_SYSINFO_DEVICE_NAME)\"
+# GLOBAL_CFLAGS += -DSYSINFO_OS_VERSION=\"$(CONFIG_SYSINFO_OS_VERSION)\"
+# GLOBAL_CFLAGS += -DSYSINFO_ARCH=\"$(HOST_ARCH)\"
+# GLOBAL_CFLAGS += -DSYSINFO_MCU=\"$(HOST_MCU_NAME)\"

--- a/platform/board/nsim_em/board.c
+++ b/platform/board/nsim_em/board.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015-2020 Alibaba Group Holding Limited
+ */
+
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "aos/init.h"
+#include "aos/kernel.h"
+#include "ulog/ulog.h"
+#include "aos/hal/uart.h"
+
+void board_tick_init(void)
+{
+
+}
+
+void board_stduart_init(void)
+{
+
+}
+
+void board_flash_init(void)
+{
+}
+
+void board_network_init(void)
+{
+
+}
+
+void board_gpio_init(void)
+{
+
+}
+
+void board_dma_init(void)
+{
+
+}

--- a/platform/board/nsim_em/k_config.c
+++ b/platform/board/nsim_em/k_config.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <k_api.h>
+#include <assert.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+void hal_reboot(void)
+{
+    printf("hal reboot\r\n");
+}
+
+#if (RHINO_CONFIG_HW_COUNT > 0)
+void soc_hw_timer_init(void)
+{
+}
+
+hr_timer_t soc_hr_hw_cnt_get(void)
+{
+    return 0;
+    //return *(volatile uint64_t *)0xc0000120;
+}
+
+lr_timer_t soc_lr_hw_cnt_get(void)
+{
+    return 0;
+}
+#endif /* RHINO_CONFIG_HW_COUNT */
+
+#if (RHINO_CONFIG_INTRPT_STACK_OVF_CHECK > 0)
+void soc_intrpt_stack_ovf_check(void)
+{
+}
+#endif
+
+#if (RHINO_CONFIG_MM_TLF > 0)
+
+#define       AOS_HEAP_BUFFER_SIZE (200*1024)
+uint8_t       aos_heap_buffer[AOS_HEAP_BUFFER_SIZE];
+k_mm_region_t g_mm_region[1];
+int           g_region_num = 1;
+
+void aos_heap_set()
+{
+    g_mm_region[0].start = aos_heap_buffer;
+    g_mm_region[0].len   = AOS_HEAP_BUFFER_SIZE;
+}
+
+#endif
+
+#if (RHINO_CONFIG_TASK_STACK_CUR_CHECK > 0)
+size_t soc_get_cur_sp()
+{
+    size_t sp = 0;
+#if defined (__GNUC__)&&!defined(__CC_ARM)
+    asm volatile(
+        "mov %0,sp\n"
+        :"=r"(sp));
+#endif
+    return sp;
+}
+static void soc_print_stack()
+{
+    void    *cur, *end;
+    int      i=0;
+    int     *p;
+
+    end   = krhino_cur_task_get()->task_stack_base + krhino_cur_task_get()->stack_size;
+    cur = (void *)soc_get_cur_sp();
+    p = (int*)cur;
+    while(p < (int*)end) {
+        if(i%4==0) {
+            printf("\r\n%08x:",(uint32_t)p);
+        }
+        printf("%08x ", *p);
+        i++;
+        p++;
+    }
+    printf("\r\n");
+    return;
+}
+#endif
+
+void soc_err_proc(kstat_t err)
+{
+    (void)err;
+    printf("soc_err_proc %d \r\n", err);
+    //krhino_backtrace_now();
+    #if (RHINO_CONFIG_TASK_STACK_CUR_CHECK > 0)
+    //soc_print_stack();
+    #endif
+    while(1);
+}
+
+krhino_err_proc_t g_err_proc = soc_err_proc;
+
+
+/**
+* krhino hook for k_hook.h
+* -- start
+*/
+#if (RHINO_CONFIG_USER_HOOK > 0)
+void krhino_idle_hook(void)
+{
+}
+
+void krhino_init_hook(void)
+{
+#if (RHINO_CONFIG_HW_COUNT > 0)
+    soc_hw_timer_init();
+#endif
+}
+
+void krhino_start_hook(void)
+{
+#if (RHINO_CONFIG_SYS_STATS > 0)
+    krhino_task_sched_stats_reset();
+#endif
+}
+
+void krhino_task_create_hook(ktask_t *task)
+{
+    (void)task;
+}
+
+void krhino_task_del_hook(ktask_t *task, res_free_t *arg)
+{
+    (void)task;
+    (void)arg;
+}
+
+void krhino_task_switch_hook(ktask_t *orgin, ktask_t *dest)
+{
+    (void)orgin;
+    (void)dest;
+    //printf("task_switch from [%s] to [%s]\r\n", orgin->task_name, dest->task_name);
+}
+
+void krhino_tick_hook(void)
+{
+}
+
+void krhino_task_abort_hook(ktask_t *task)
+{
+    (void)task;
+}
+
+void krhino_mm_alloc_hook(void *mem, size_t size)
+{
+    (void)mem;
+    (void)size;
+}
+
+void krhino_idle_pre_hook(void)
+{
+}
+#endif
+/**
+* krhino hook for k_hook.h
+* -- end
+*/

--- a/platform/board/nsim_em/k_config.h
+++ b/platform/board/nsim_em/k_config.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef K_CONFIG_H
+#define K_CONFIG_H
+
+/* kernel feature conf */
+#ifndef RHINO_CONFIG_SEM
+#define RHINO_CONFIG_SEM                     1
+#endif
+#ifndef RHINO_CONFIG_QUEUE
+#define RHINO_CONFIG_QUEUE                   1
+#endif
+#ifndef RHINO_CONFIG_TASK_SEM
+#define RHINO_CONFIG_TASK_SEM                1
+#endif
+#ifndef RHINO_CONFIG_EVENT_FLAG
+#define RHINO_CONFIG_EVENT_FLAG              1
+#endif
+#ifndef RHINO_CONFIG_TIMER
+#define RHINO_CONFIG_TIMER                   1
+#endif
+#ifndef RHINO_CONFIG_BUF_QUEUE
+#define RHINO_CONFIG_BUF_QUEUE               1
+#endif
+#ifndef RHINO_CONFIG_MM_BLK
+#define RHINO_CONFIG_MM_BLK                  1
+#endif
+#ifndef RHINO_CONFIG_MM_DEBUG
+#define RHINO_CONFIG_MM_DEBUG                1
+#endif
+#ifndef RHINO_CONFIG_MM_TLF
+#define RHINO_CONFIG_MM_TLF                  1
+#endif
+#ifndef RHINO_CONFIG_MM_TLF_BLK_SIZE
+#define RHINO_CONFIG_MM_TLF_BLK_SIZE         8192
+#endif
+/* kernel task conf */
+#ifndef RHINO_CONFIG_TASK_INFO
+#define RHINO_CONFIG_TASK_INFO               1
+#endif
+#ifndef RHINO_CONFIG_TASK_DEL
+#define RHINO_CONFIG_TASK_DEL                1
+#endif
+#ifndef RHINO_CONFIG_TASK_STACK_OVF_CHECK
+#define RHINO_CONFIG_TASK_STACK_OVF_CHECK    1
+#endif
+#ifndef RHINO_CONFIG_SCHED_RR
+#define RHINO_CONFIG_SCHED_RR                1
+#endif
+#ifndef RHINO_CONFIG_TIME_SLICE_DEFAULT
+#define RHINO_CONFIG_TIME_SLICE_DEFAULT      10
+#endif
+#ifndef RHINO_CONFIG_PRI_MAX
+#define RHINO_CONFIG_PRI_MAX                 62
+#endif
+#ifndef RHINO_CONFIG_USER_PRI_MAX
+#define RHINO_CONFIG_USER_PRI_MAX            (RHINO_CONFIG_PRI_MAX - 2)
+#endif
+
+/* kernel workqueue conf */
+#ifndef RHINO_CONFIG_WORKQUEUE
+#define RHINO_CONFIG_WORKQUEUE               1
+#endif
+
+/* kernel mm_region conf */
+#ifndef RHINO_CONFIG_MM_REGION_MUTEX
+#define RHINO_CONFIG_MM_REGION_MUTEX         0
+#endif
+
+/* kernel timer&tick conf */
+#ifndef RHINO_CONFIG_HW_COUNT
+#define RHINO_CONFIG_HW_COUNT                1
+#endif
+#ifndef RHINO_CONFIG_TICKS_PER_SECOND
+#define RHINO_CONFIG_TICKS_PER_SECOND        100
+#endif
+#ifndef RHINO_CONFIG_TIMER_TASK_STACK_SIZE
+#define RHINO_CONFIG_TIMER_TASK_STACK_SIZE   200
+#endif
+#ifndef RHINO_CONFIG_TIMER_TASK_PRI
+#define RHINO_CONFIG_TIMER_TASK_PRI          5
+#endif
+
+#ifndef RHINO_CONFIG_INTRPT_STACK_OVF_CHECK
+#define RHINO_CONFIG_INTRPT_STACK_OVF_CHECK  0
+#endif
+/* kernel dyn alloc conf */
+#ifndef RHINO_CONFIG_KOBJ_DYN_ALLOC
+#define RHINO_CONFIG_KOBJ_DYN_ALLOC          1
+#endif
+#if (RHINO_CONFIG_KOBJ_DYN_ALLOC > 0)
+#ifndef RHINO_CONFIG_K_DYN_TASK_STACK
+#define RHINO_CONFIG_K_DYN_TASK_STACK        256
+#endif
+#ifndef RHINO_CONFIG_K_DYN_MEM_TASK_PRI
+#define RHINO_CONFIG_K_DYN_MEM_TASK_PRI      5
+#endif
+#endif
+
+/* kernel idle conf */
+#ifndef RHINO_CONFIG_IDLE_TASK_STACK_SIZE
+#define RHINO_CONFIG_IDLE_TASK_STACK_SIZE    100
+#endif
+
+/* kernel hook conf */
+#ifndef RHINO_CONFIG_USER_HOOK
+#define RHINO_CONFIG_USER_HOOK               1
+#endif
+
+/* kernel stats conf */
+#ifndef RHINO_CONFIG_SYS_STATS
+#define RHINO_CONFIG_SYS_STATS               1
+#endif
+
+#ifndef RHINO_CONFIG_CPU_NUM
+#define RHINO_CONFIG_CPU_NUM                 1
+#endif
+
+#ifndef SYSINFO_DEVICE_NAME
+#define SYSINFO_DEVICE_NAME                  "synopsys nsim_em"
+#endif
+
+#ifndef CLI_UART
+#define CLI_UART 0
+#endif
+
+#endif /* K_CONFIG_H */

--- a/platform/board/nsim_em/startup.c
+++ b/platform/board/nsim_em/startup.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <k_api.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "aos/init.h"
+#include "embARC.h"
+#include "arc/arc_timer.h"
+#include "arc/arc_exception.h"
+
+/*
+main task stask size(byte)
+*/
+#define OS_MAIN_TASK_STACK 1024
+#define OS_MAIN_TASK_PRI 32
+
+/*  For user config
+    kinit.argc = 0;
+    kinit.argv = NULL;
+    kinit.cli_enable = 1;
+*/
+static kinit_t kinit = {0, NULL, 1};
+static ktask_t *g_main_task;
+
+extern void aos_heap_set();
+
+#ifndef AOS_BINS
+extern int application_start(int argc, char **argv);
+#endif
+
+static void sys_init(void)
+{
+    aos_components_init(&kinit);
+
+    #ifndef AOS_BINS
+    application_start(kinit.argc, kinit.argv);  /* jump to app/example entry */
+    #endif
+}
+
+static void aos_hw_timer_isr(int vector, void *param)
+{
+    arc_timer_int_clear(BOARD_OS_TIMER_ID);
+//    krhino_intrpt_enter();
+    krhino_tick_proc();
+//    krhino_intrpt_exit();
+}
+
+int aos_hw_timer_init(void)
+{
+
+    unsigned int cyc = BOARD_CPU_CLOCK / RHINO_CONFIG_TICKS_PER_SECOND;
+
+    int_disable(BOARD_OS_TIMER_INTNO); /* disable os timer interrupt */
+    arc_timer_stop(BOARD_OS_TIMER_ID);
+    arc_timer_start(BOARD_OS_TIMER_ID, TIMER_CTRL_IE | TIMER_CTRL_NH, cyc);
+
+    int_handler_install(BOARD_OS_TIMER_INTNO, (INT_HANDLER_T)aos_hw_timer_isr);
+    int_pri_set(BOARD_OS_TIMER_INTNO, INT_PRI_MIN + 1); /* currently, firq(INT_PRI_MIN) not supported*/
+    int_enable(BOARD_OS_TIMER_INTNO);
+
+    return 0;
+}
+
+int main(void)
+{
+    aos_hw_timer_init();
+    /*mm heap set*/
+    aos_heap_set();
+    /*kernel init, malloc can use after this!*/
+    krhino_init();
+
+    /*main task to run */
+    krhino_task_dyn_create(&g_main_task, "main_task", 0, OS_MAIN_TASK_PRI, 0, OS_MAIN_TASK_STACK, (task_entry_t)sys_init, 1);
+
+    /*kernel start schedule!*/
+    krhino_start();
+
+    /*never run here*/
+    return 0;
+}

--- a/platform/mcu/embarc/Config.in
+++ b/platform/mcu/embarc/Config.in
@@ -1,0 +1,5 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##

--- a/platform/mcu/embarc/README.md
+++ b/platform/mcu/embarc/README.md
@@ -1,0 +1,5 @@
+# embarc_bsp requirement
+
+please get embarc_bsp for github, run command below in current folder:
+
+git clone https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_bsp.git -b upstream

--- a/platform/mcu/embarc/aos.mk
+++ b/platform/mcu/embarc/aos.mk
@@ -1,0 +1,63 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##
+
+NAME := mcu_embarc
+
+HOST_OPENOCD := synopsys_arc_embarc
+
+$(NAME)_MBINS_TYPE := kernel
+$(NAME)_VERSION    := 1.0.1
+$(NAME)_SUMMARY    := driver & sdk for Synopsys ARC processors
+
+$(NAME)_COMPONENTS += arch_arc
+
+$(NAME)_SOURCES := hal/hal_uart.c
+
+$(info [embarc.aos.info]: BOARD = $(BOARD))
+$(info [embarc.aos.info]: BD_VER = $(BD_VER))
+
+CURRENT_PATH := $($(NAME)_LOCATION)
+
+EMBARC_OUT_DIR = embarc_bsp/obj_$(BOARD)_$(BD_VER)/$(TOOLCHAIN)_$(CUR_CORE)
+
+$(info [embarc.aos.info]: EMBARC_OUT_DIR = $(EMBARC_OUT_DIR))
+
+GCC_ARG := ./platform/mcu/embarc/$(EMBARC_OUT_DIR)/embARC_generated/gcc.arg
+CCAC_ARG := ./platform/mcu/embarc/$(EMBARC_OUT_DIR)/embARC_generated/ccac.arg
+GCC_LDF_FILE := ./platform/mcu/embarc/$(EMBARC_OUT_DIR)/linker_gnu.ldf
+CCAC_LDF_FILE := ./platform/mcu/embarc/$(EMBARC_OUT_DIR)/linker_mw.ldf
+
+GLOBAL_INCLUDES += embarc_bsp/board/nsim/configs/10
+GLOBAL_INCLUDES += $(EMBARC_OUT_DIR)/embARC_generated
+GLOBAL_INCLUDES += embarc_bsp
+GLOBAL_INCLUDES += embarc_bsp/board
+GLOBAL_INCLUDES += embarc_bsp/include
+GLOBAL_INCLUDES += embarc_bsp/include/device/designware
+GLOBAL_INCLUDES += embarc_bsp/include/device/subsystem
+GLOBAL_INCLUDES += embarc_bsp/library
+
+ifeq ($(COMPILER),mwdt)
+GLOBAL_CFLAGS += @$(CCAC_ARG)
+GLOBAL_CXXFLAGS += @$(CCAC_ARG)
+GLOBAL_ASMFLAGS += @$(CCAC_ARG)
+GLOBAL_LDFLAGS += @$(CCAC_ARG) -Hpurge -Hnocopyr -Hnosdata -Hnocrt $(CCAC_LDF_FILE)
+else
+GLOBAL_CFLAGS += @$(GCC_ARG)
+GLOBAL_CXXFLAGS += @$(GCC_ARG)
+GLOBAL_ASMFLAGS += @$(GCC_ARG)
+GLOBAL_LDFLAGS += @$(GCC_ARG) -Wl,--script=$(GCC_LDF_FILE)
+endif
+
+
+$(NAME)_PREBUILT_LIBRARY := $(EMBARC_OUT_DIR)/board/board.o
+$(NAME)_PREBUILT_LIBRARY += $(EMBARC_OUT_DIR)/arc/startup/arc_startup.o
+$(NAME)_PREBUILT_LIBRARY += $(EMBARC_OUT_DIR)/arc/startup/arc_cxx_support.o
+$(NAME)_PREBUILT_LIBRARY += $(EMBARC_OUT_DIR)/libboard_nsim.a
+$(NAME)_PREBUILT_LIBRARY += $(EMBARC_OUT_DIR)/libcpuarc.a
+$(NAME)_PREBUILT_LIBRARY += $(EMBARC_OUT_DIR)/libembarc_libc.a
+$(NAME)_PREBUILT_LIBRARY += $(EMBARC_OUT_DIR)/libembarc_console.a
+
+EXTRA_TARGET_MAKEFILES +=  $(CURRENT_PATH)/embarc_bsp.mk

--- a/platform/mcu/embarc/embarc_bsp.mk
+++ b/platform/mcu/embarc/embarc_bsp.mk
@@ -1,0 +1,44 @@
+##
+# Copyright (c) 2020, Synopsys, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+##
+
+EXTRA_PRE_BUILD_TARGETS += gen_embarc_bsp_lib
+EXTRA_POST_BUILD_TARGETS += mdb_debug
+
+export EMBARC_ROOT := ./platform/mcu/embarc/embarc_bsp
+export OUT_DIR_ROOT := ./platform/mcu/embarc/embarc_bsp
+
+EMBARC_BSP_TEST_FILE = $(EMBARC_ROOT)/arc/startup/arc_startup.s
+
+ifeq ($(wildcard $(EMBARC_BSP_TEST_FILE)),)
+$(info )
+$(info )
+$(info )
+$(info ######################################################################################################)
+$(info #                                                                                                    #)
+$(info #    embarc_bsp not exist!!!                                                                         #)
+$(info #    please git embarc_bsp from github                                                               #)
+$(info #    run cmd blow in folder <SOURCE_ROOT>/platform/mcu/embarc:                                       #)
+$(info #    git clone https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_bsp.git -b upstream    #)
+$(info #                                                                                                    #)
+$(info ######################################################################################################)
+$(info )
+$(info )
+$(info )
+$(error [Makefile.error]: embarc_bsp not exist!!!)
+endif
+
+$(info [embarc_bsp.mk.info] EMBARC_ROOT = $(EMBARC_ROOT))
+$(info [embarc_bsp.mk.info]: BOARD = $(BOARD))
+$(info [embarc_bsp.mk.info]: BD_VER = $(BD_VER))
+$(info [embarc_bsp.mk.info]: TOOLCHAIN = $(TOOLCHAIN))
+
+gen_embarc_bsp_lib:
+	$(info [embarc_bsp.mk.build] EMBARC_ROOT = $(EMBARC_ROOT))
+	$(QUIET)$(ECHO) Making $(notdir $@)
+	$(QUIET) make -r $(JOBSNO) $(SILENT) -f $(EMBARC_ROOT)/options/options.mk V=1 embarc_lib
+
+mdb_debug:
+	$(info [nsim_em.mdb_debug]: mdb_debug)

--- a/platform/mcu/embarc/hal/hal_uart.c
+++ b/platform/mcu/embarc/hal/hal_uart.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Synopsys, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include "aos/hal/uart.h"
+#include "k_api.h"
+#include "embARC.h"
+
+int32_t hal_uart_send(uart_dev_t *uart, const void *data, uint32_t size, uint32_t timeout)
+{
+    DEV_UART_PTR embarc_uart;
+    int ret;
+
+    embarc_uart = uart_get_dev(uart->port);
+
+    if (embarc_uart == NULL)
+    {
+        return -1;
+    }
+
+    ret = embarc_uart->uart_write(data, size);
+
+    if (ret < 0) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+int32_t hal_uart_recv_II(uart_dev_t *uart, void *data, uint32_t expect_size,
+                      uint32_t *recv_size, uint32_t timeout)
+{
+    DEV_UART_PTR embarc_uart;
+    int ret, rx_count;
+
+    embarc_uart = uart_get_dev(uart->port);
+
+    if (embarc_uart == NULL)
+    {
+        return -1;
+    }
+
+    rx_count = embarc_uart->uart_read(data, expect_size);
+
+    if(recv_size)
+    {
+        *recv_size = rx_count;
+    }
+
+    if(rx_count != 0)
+    {
+        ret = 0;
+    }
+    else
+    {
+        ret = -1;
+    }
+
+    return ret;
+}
+
+int32_t hal_uart_init(uart_dev_t *uart)
+{
+    int32_t ret = 0;
+    DEV_UART_PTR embarc_uart;
+
+    embarc_uart = uart_get_dev(uart->port);
+
+    if (uart == NULL)
+    {
+        return -1;
+    }
+
+    /* default format: 8bits, no parity, 1 stop bits */
+    ret = embarc_uart->uart_open(uart->config.baud_rate);
+
+    if (ret != E_OPNED && ret != E_OK) {
+        return -1;
+    }
+
+    ret = 0;
+    return ret;
+}
+
+int32_t hal_uart_finalize(uart_dev_t *uart)
+{
+    return 0;
+}


### PR DESCRIPTION
* build: build_rules: enhancement and fix

generate .d file for cpp and assembly file.
add defines to assembly file compile options.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

* build: toolchain: add basic synopsys arc gnu toolchain support

add basic synopsys arc gnu toolchain support

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

* build: toolchain: add basic synopsys mwdt toolchain support

add basic synopsys mwdt toolchain support

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

* paltform: arch: add basic synopsys arc processor arch support

add basic synopsys arc processor arch support

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

* platform: mcu: add basic synopsys embarc  support

add basic synopsys embarc  support.
The embARC Board Support Package (BSP) is a software distribution
aimed at facilitating the development and evaluation of embedded
systems based on ARCv2 processors.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

* board: nsim_em: add basic support for synopsys arc virtual board nsim

add basic support for synopsys arc virtual board nsim

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

**Is your feature request related to a problem? Please describe.**


**Describe the solution you'd like**


**Additional context**
